### PR TITLE
Fix `Cannot access protected property of $connection`

### DIFF
--- a/core/v2/authentication.md
+++ b/core/v2/authentication.md
@@ -63,7 +63,7 @@ $dispatcher = Container::getEventDispatcher();
 $message = '';
 
 $dispatcher->listen(Failed::class, function (Failed $event) use (&$message) {
-    $ldap = $event->connection->getLdapConnection();
+    $ldap = $event->getConnection();
 
     // The diagnostic message will be available here.
     $error = $ldap->getDiagnosticMessage();


### PR DESCRIPTION
Using `$event->connection->getLdapConnection()` gives the below error due to connection being protected

```
Error
Cannot access protected property LdapRecord\Auth\Events\Failed::$connection
```