### PR TITLE
Validation error for username

### DIFF
--- a/laravel/v2/auth/plain/laravel-breeze.md
+++ b/laravel/v2/auth/plain/laravel-breeze.md
@@ -232,7 +232,7 @@ public function authenticate()
         RateLimiter::hit($this->throttleKey());
 
         throw ValidationException::withMessages([
-            'email' => __('auth.failed'),
+            'username' => __('auth.failed'),
         ]);
     }
 


### PR DESCRIPTION
We should show the validation error for username field when username is using.