### PR TITLE
Adding App\Ldap\Scopes\OnlyAccountingUsers

### DIFF
--- a/laravel/v2/auth/restricting-login.md
+++ b/laravel/v2/auth/restricting-login.md
@@ -209,6 +209,7 @@ can add the global scope to the model inside your `AuthServiceProvider::boot()` 
 
 ```php
 // app/Providers/AuthServiceProvider.php
+use App\Ldap\Scopes\OnlyAccountingUsers;
 
 /**
  * Register any authentication / authorization services.


### PR DESCRIPTION
I think we should insert the App\Ldap\Scopes\OnlyAccountingUsers trait onto AuthServiceProvider.php if we want Scopes to work properly