### PR TITLE
Updated ServiceProvider example for v3

### DIFF
--- a/laravel/v3/events.md
+++ b/laravel/v3/events.md
@@ -86,7 +86,7 @@ class LdapEventServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $dispatcher = Container::getEventDispatcher();
+        $dispatcher = Container::getDispatcher();
 
         foreach ($this->listen as $event => $listeners) {
             foreach (array_unique($listeners) as $listener) {


### PR DESCRIPTION
The ServiceProvider example for the 'Events' section is outdated and does not work in v3.  This fixes the example.
Although not in this PR, it should specified that the ServiceProvider needs to be added to your list of providers in `config/app.php`.