### PR TITLE
Schedule tasks in Laravel 11 differs from current example

### DIFF
--- a/laravel/v3/auth/database/importing.md
+++ b/laravel/v3/auth/database/importing.md
@@ -112,11 +112,11 @@ Place the following in your `routes/console.php`:
 use Illuminate\Support\Facades\Schedule;
 
 Schedule::command('ldap:import users', [
-        '--no-interaction',
-        '--restore',
-        '--delete',
-        '--filter' => '(objectclass=user)',
-    ])->daily();
+    '--no-interaction',
+    '--restore',
+    '--delete',
+    '--filter' => '(objectclass=user)',
+])->daily();
 ```
 
 ### Laravel <= 10

--- a/laravel/v3/auth/database/importing.md
+++ b/laravel/v3/auth/database/importing.md
@@ -102,7 +102,26 @@ Successfully imported / synchronized 2 user(s).
 
 ## Scheduling the command
 
-To run the import as a scheduled job, place the following in your `app/Console/Kernel.php` in the command scheduler:
+To run the import as a scheduled job, refer to the different Laravel versions below:
+
+### Laravel >= 11
+
+Place the following in your `routes/console.php`:
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('ldap:import users', [
+        '--no-interaction',
+        '--restore',
+        '--delete',
+        '--filter' => '(objectclass=user)',
+    ])->daily();
+```
+
+### Laravel <= 10
+
+Place the following in your `app/Console/Kernel.php` in the command scheduler:
 
 ```php
 protected function schedule(Schedule $schedule)


### PR DESCRIPTION
A new Laravel 11 project does not have the `app/Console/Kernel.php` and defines the scheduled tasks in the `routes/console.php` instead.

Added the code example necessary for the new version with a distinction between 10 and 11+.

Not sure if this is the way you'd like to differentiate between them, or if linking to Laravels own docs is more appropriate, let me know what you think.

(This is my first contribution ever, so apologies for any mistake! :smile: )